### PR TITLE
[Fix] pluralized sections break the navigation

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,6 +6,9 @@ googleAnalytics = ""
 theme = "showcase"
 disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
 
+# this setting should always be set to false, otherwise it will break the section navigation bar
+pluralizelisttitles = false
+
 [params]
   author = "showcase"
   description = "Minimal, one page, theme for showcasing your work"


### PR DESCRIPTION
without this setting, the navigation is broken if you create sections with singular names, like "book" instead of "books". it will cause the navigation bar to filter with the pluralized name (and it won't find anything as the section is singular)